### PR TITLE
Disable stylelint on JS files

### DIFF
--- a/packages/stylelint-config/index.js
+++ b/packages/stylelint-config/index.js
@@ -1,5 +1,6 @@
 module.exports = {
   plugins: ["stylelint-order"],
+  ignoreFiles: ["**/*.{js|ts|jsx|tsx}"],
   rules: {
     "declaration-bang-space-after": "never",
     "declaration-bang-space-before": "always",


### PR DESCRIPTION
When using stylelint in my vscode, it tried to lint js files as well, let's add them ignored.