### PR TITLE
[breaking] Up supported browsers

### DIFF
--- a/packages/browserslist-config/index.js
+++ b/packages/browserslist-config/index.js
@@ -2,17 +2,17 @@
 // source https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Spread_syntax
 const spreadInObjectSupport = [
   // Desktop
-  "chrome >= 60",
+  "chrome >= 69",
   "edge >= 79",
-  "firefox >= 55",
-  "opera >= 47",
-  "safari >= 11.1",
+  "firefox >= 62",
+  "opera >= 56",
+  "safari >= 12",
   // Mobile
-  "android >= 60",
-  "and_chr >= 60",
-  "and_ff >= 55",
-  "ios_saf >= 11.3",
-  "samsung >= 8.2",
+  "android >= 69",
+  "and_chr >= 69",
+  "and_ff >= 62",
+  "ios_saf >= 12",
+  "samsung >= 10.1",
 ]
 
 module.exports = [


### PR DESCRIPTION
Keep our list updated so we can remove some unnecessary polyfills.

Browser versions not supported anymore (29 versions removed):
```diff
- chrome 68	
- chrome 67	
- chrome 66	
- chrome 65	
- chrome 64	
- chrome 63	
- chrome 62	
- chrome 61	
- chrome 60
- firefox 61	
- firefox 60	
- firefox 59	
- firefox 58	
- firefox 57	
- firefox 56	
- firefox 55
- ios_saf 11.3-11.4	
- opera 55	
- opera 54	
- opera 53	
- opera 52	
- opera 51	
- opera 50	
- opera 49	
- opera 48	
- opera 47
- safari 11.1
- samsung 9.2	
- samsung 8.2
```

## Browser version detection
Now supported versions are minmum to [`Array.prototype.flat` support](https://caniuse.com/array-flat) (`[].flat()`) so we can use it as capability testing.
<img width="1446" alt="Screenshot 2023-05-09 at 15 07 01" src="https://github.com/drivy/frontend-configs/assets/10224453/91ed3806-3df5-4647-8ea2-0d5a0f54a9d3">
