### PR TITLE
Enable bugfixes option for babel

### DIFF
--- a/packages/babel-preset-app/index.js
+++ b/packages/babel-preset-app/index.js
@@ -34,6 +34,7 @@ module.exports = declare(function (api) {
     // Adds specific imports for polyfills when they are used in each file.
     // We take advantage of the fact that a bundler will load the same polyfill only once.
     useBuiltIns: "usage",
+    bugfixes: true,
     corejs: "3.30",
   }
 


### PR DESCRIPTION
According to [Babel documentation](https://babeljs.io/docs/babel-preset-env):

> By default, @babel/preset-env (and Babel plugins in general) grouped ECMAScript syntax features into collections of closely related smaller features. These groups can be large and include a lot of edge cases, for example "function arguments" includes destructured, default and rest parameters. From this grouping information, Babel enables or disables each group based on the browser support target you specify to @babel/preset-env’s targets option.
>
> When this option is enabled, @babel/preset-env tries to compile the broken syntax to the closest non-broken modern syntax supported by your target browsers. Depending on your targets and on how many modern syntax you are using, this can lead to a significant size reduction in the compiled app. This option merges the features of [@babel/preset-modules](https://github.com/babel/preset-modules) without having to use another preset.