### PR TITLE
[browserslist] Remove Android < 4.4.4 support

### DIFF
--- a/packages/browserslist-config/index.js
+++ b/packages/browserslist-config/index.js
@@ -20,4 +20,5 @@ module.exports = [
   "not ie 11",
   "not samsung 4",
   "not op_mini all",
+  "not android <= 4.4.4",
 ].concat(spreadInObjectSupport)


### PR DESCRIPTION
So we can get rid of a lot polyfills used for that not that used browser (global 0.34%, 0.06% for EU, 0.05% for NA).
Also, the minimum version we support for our mobile application is Android 6.0.