### PR TITLE
Continue to disable block-scoping for const/let variables

### DIFF
--- a/packages/babel-preset-app/index.js
+++ b/packages/babel-preset-app/index.js
@@ -61,6 +61,10 @@ module.exports = declare(function (api, options) {
       require.resolve("@babel/plugin-syntax-dynamic-import"),
       isTestEnv && require.resolve("babel-plugin-dynamic-import-node"),
       require.resolve("@babel/plugin-proposal-class-properties"),
+      // Continue to disable block-scoping for const/let variables
+      // and transform them to var variables.
+      // This is considered as technical debt and should be migrated to block-scoping
+      require.resolve("@babel/plugin-transform-block-scoping"),
       [
         require.resolve("@babel/plugin-transform-runtime"),
         {

--- a/packages/babel-preset-app/package.json
+++ b/packages/babel-preset-app/package.json
@@ -20,6 +20,7 @@
     "@babel/core": "^7.21.8",
     "@babel/plugin-proposal-class-properties": "^7.18.6",
     "@babel/plugin-syntax-dynamic-import": "^7.8.3",
+    "@babel/plugin-transform-block-scoping": "^7.21.0",
     "@babel/plugin-transform-runtime": "^7.21.4",
     "@babel/preset-env": "^7.21.5",
     "@babel/preset-react": "^7.18.6",


### PR DESCRIPTION
Since we remove the support of 4.4.4 browser, all ouf our browsers are now compatible with `const`/`let` support. When doing this change, we noticed that our JS code are completely handling the block-scoping behaviour that `const`/`let` is allowing.

As temporary alternative, we decided to bring back that legacy behaviour only thanks to the plugin [@babel/plugin-transform-block-scoping](https://babeljs.io/docs/babel-plugin-transform-block-scoping/).

This is considered as technical debt and should be migrated to block-scoping.